### PR TITLE
fixed requirements.txt (API and Dashboards)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 .env
-
 __pycache__/
 *.py[cod]
-
 *.egg-info/
-
-/venv
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,3 @@ python-jose==3.5.0
 starlette==0.46.1
 cachetools==5.5.2
 passlib==1.7.4
-streamlit==1.47.1
-plotly==6.2.0

--- a/src/dashboards/requirements.txt
+++ b/src/dashboards/requirements.txt
@@ -1,0 +1,2 @@
+streamlit==1.47.1
+plotly==6.2.0


### PR DESCRIPTION
### 🔄 Summary of Changes

To resolve a **deployment size limit error on Vercel**, the `streamlit` and `plotly` dependencies were **removed from the main `requirements.txt`** and moved to a **separate file (`src/dashboards/requirements.txt`)**.

---

### 📦 Reason

Vercel enforces a **250MB unzipped limit for serverless functions**, and including `streamlit` and `plotly` caused the deployment to exceed that limit. These libraries are only used for the dashboard and not needed in the API deployed to Vercel.

---
